### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DiffDrive	 KEYWORD1
+DiffDrive	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)

--- a/keywords.txt
+++ b/keywords.txt
@@ -12,14 +12,14 @@ DiffDrive	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-forward	 		KEYWORD2
-reverse	 		KEYWORD2
-left	 		KEYWORD2
-right	 		KEYWORD2
-hardLeft 		KEYWORD2
-hardRight 		KEYWORD2
-brake			KEYWORD2
-reverseLeft		KEYWORD2
+forward	KEYWORD2
+reverse	KEYWORD2
+left	KEYWORD2
+right	KEYWORD2
+hardLeft	KEYWORD2
+hardRight	KEYWORD2
+brake	KEYWORD2
+reverseLeft	KEYWORD2
 reverseRight	KEYWORD2
 
 


### PR DESCRIPTION
- Remove leading space from keywords.txt identifier.
- Use a single tab field separator.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords